### PR TITLE
Properties require at least one generator

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,6 @@
 
 Generators will expose some composition, for example `zip`, to combine the elements of two generation streams into a tuple. However, at the property-level, it might be advantageous to not rely on such combinators, as it takes away the capability to resize/shrink generators independently.
 
-For example, say we have a base generator which produces integers between 0 and 20. We might have create two generators by filtering the original generator by `x > 10` and `x < 10`. Intuitively, one generator might have a much better chance of succeeding at lower sizes, and the other at higher sizes. Because we need both to succeed to test the property, the property need to be able to poke at the generators independently and infer some heuristics about what sizes seem to generate stuff, independently.
+For example, say we have a base generator which produces integers between 0 and 20. We might create two generators by filtering the original generator by `x > 10` and `x < 10`. Intuitively, one generator might have a much better chance of succeeding at lower sizes, and the other at higher sizes. Because we need both to succeed to test the property, the property needs the generators to run at different sizes in order for the property to have a reasonable chance of fulfilling its values. A property should be able to poke at the generators independently, and infer some heuristics about what sizes seem to generate stuff.
 
-_Size is, most likely, closely related to a generators chance of successfully producing a value._
+_Size is (most likely) closely related to a generators chance of successfully producing a value._

--- a/packages/pbt-properties-core/src/Property.ts
+++ b/packages/pbt-properties-core/src/Property.ts
@@ -1,9 +1,7 @@
 import { Gen } from 'pbt-generator-core';
 import { success, exhaustionFailure, predicateFailure, PropertyResult } from './PropertyResult';
 import { PropertyConfig, validateConfig } from './PropertyConfig';
-import runProperty, { PropertyFunction } from './runProperty';
-
-type Gens = Array<Gen<any>>;
+import runProperty, { Gens, PropertyFunction } from './runProperty';
 
 type GenValue<T> = T extends Gen<infer U> ? U : never;
 
@@ -14,44 +12,31 @@ export interface Property<T> {
   _?: T;
 }
 
-const constantProperty = (f: PropertyFunction<[]>): Property<[]> => (config) => {
-  const validationError = validateConfig(config);
-  if (validationError) return validationError;
-
-  // It's kinda meaningless to repeat a constant property, but we do so for API symmetry.
-  for (let i = 0; i < config.iterations; i++) {
-    if (f() === false) {
-      return predicateFailure();
-    }
-  }
-
-  return success();
-};
-
-const variableProperty = <TGens extends Gens>(gs: TGens, f: PropertyFunction<TGens>): Property<GenValues<TGens>> => (
-  config,
-) => {
-  const validationError = validateConfig(config);
-  if (validationError) return validationError;
-
-  const { iterations } = config;
-  const { lastIteration } = runProperty(gs, f, config);
-
-  switch (lastIteration.iterationStatus) {
-    case 'success':
-      return success();
-    case 'exhaustionFailure':
-      return exhaustionFailure(iterations, lastIteration.iterationNumber - 1);
-    case 'predicateFailure':
-      return predicateFailure();
-  }
-};
-
 export const property = <TGens extends Gens>(
   ...args: [...TGens, PropertyFunction<TGens>]
 ): Property<GenValues<TGens>> => {
+  /* istanbul ignore next */
+  if (args.length <= 1) {
+    throw new Error('Property requires at least one Gen');
+  }
+
   const gs = args.slice(0, args.length - 1) as TGens;
   const f = args[args.length - 1] as PropertyFunction<TGens>;
 
-  return gs.length === 0 ? ((constantProperty(f) as unknown) as Property<GenValues<TGens>>) : variableProperty(gs, f);
+  return (config) => {
+    const validationError = validateConfig(config);
+    if (validationError) return validationError;
+
+    const { iterations } = config;
+    const { lastIteration } = runProperty(gs, f, config);
+
+    switch (lastIteration.iterationStatus) {
+      case 'success':
+        return success();
+      case 'exhaustionFailure':
+        return exhaustionFailure(iterations, lastIteration.iterationNumber - 1);
+      case 'predicateFailure':
+        return predicateFailure();
+    }
+  };
 };

--- a/packages/pbt-properties-core/src/index.ts
+++ b/packages/pbt-properties-core/src/index.ts
@@ -1,4 +1,4 @@
-export { PropertyFunction } from './runProperty';
+export { Gens, PropertyFunction } from './runProperty';
 export { property, Property } from './Property';
 export { PropertyConfig } from './PropertyConfig';
 export { PropertyResult, PropertySuccess, PropertyFailure, PropertyValidationFailure } from './PropertyResult';

--- a/packages/pbt-properties-core/src/runProperty.ts
+++ b/packages/pbt-properties-core/src/runProperty.ts
@@ -4,7 +4,7 @@ import { map, take } from 'ix/iterable/operators';
 import { indexed, mapIndexed, takeWhileInclusive } from './iterableOperators';
 import { PropertyConfig, validateConfig } from './PropertyConfig';
 
-type Gens = Array<Gen<any>>;
+export type Gens = [Gen<any>, ...Gen<any>[]];
 
 type GenValue<T> = T extends Gen<infer U> ? U : never;
 

--- a/packages/pbt-properties-core/test/helpers/arbitraries.ts
+++ b/packages/pbt-properties-core/test/helpers/arbitraries.ts
@@ -1,6 +1,6 @@
 import * as fc from 'fast-check';
 import { Gen, Seed } from 'pbt-generator-core';
-import { PropertyFunction, PropertyConfig } from '../../src';
+import { Gens, PropertyFunction, PropertyConfig } from '../../src';
 import { DEFAULT_MAX_ITERATIONS } from './constants';
 import { GenStub } from './stubs';
 
@@ -61,9 +61,9 @@ const resolveGensConstraints = (constraints: Partial<GensConstraints>): GensCons
   ...resolveGenConstraints(constraints),
 });
 
-export const arbitraryGens = (constraints: Partial<GensConstraints>): fc.Arbitrary<Array<Gen<unknown>>> => {
+export const arbitraryGens = (constraints: Partial<GensConstraints>): fc.Arbitrary<Gens> => {
   const resolvedConstraints = resolveGensConstraints(constraints);
-  return fc.array(resolvedConstraints.genArbitrary, resolvedConstraints.minGens, 20);
+  return fc.array(resolvedConstraints.genArbitrary, resolvedConstraints.minGens, 20) as fc.Arbitrary<Gens>;
 };
 
 export const arbitraryNonEmptyGen = (): fc.Arbitrary<Gen<unknown>> => arbitraryGen({ minLength: 1 });
@@ -71,13 +71,13 @@ export const arbitraryNonEmptyGen = (): fc.Arbitrary<Gen<unknown>> => arbitraryG
 export const arbitraryExhaustingGen = (): fc.Arbitrary<Gen<unknown>> =>
   arbitraryGenValues().map((values) => GenStub.exhaustAfter(values));
 
-export const arbitrarySucceedingPropertyFunction = <T extends Array<Gen<any>>>(): fc.Arbitrary<PropertyFunction<T>> =>
+export const arbitrarySucceedingPropertyFunction = <T extends Gens>(): fc.Arbitrary<PropertyFunction<T>> =>
   fc.constant(() => true);
 
-export const arbitraryFailingPropertyFunction = <T extends Array<Gen<any>>>(): fc.Arbitrary<PropertyFunction<T>> =>
+export const arbitraryFailingPropertyFunction = <T extends Gens>(): fc.Arbitrary<PropertyFunction<T>> =>
   fc.constant(() => false);
 
-export const arbitraryPropertyFunction = <T extends Array<Gen<any>>>(): fc.Arbitrary<PropertyFunction<T>> =>
+export const arbitraryPropertyFunction = <T extends Gens>(): fc.Arbitrary<PropertyFunction<T>> =>
   fc.oneof(arbitrarySucceedingPropertyFunction(), arbitraryFailingPropertyFunction());
 
 export const arbitraryIterations = (maxIterations: number = DEFAULT_MAX_ITERATIONS): fc.Arbitrary<number> =>

--- a/packages/pbt-properties-core/test/properties.test.ts
+++ b/packages/pbt-properties-core/test/properties.test.ts
@@ -1,4 +1,4 @@
-import { property } from '../src';
+import { Gens, property } from '../src';
 import { stableAssert, stableProperty } from './helpers/stableApi';
 import {
   arbitraryExtendableTuple,
@@ -10,6 +10,7 @@ import {
   arbitrarilyShuffleArray,
 } from './helpers/arbitraries';
 import { GenStub } from './helpers/stubs';
+import fc from 'fast-check';
 
 test('The test function receives a value from the generator', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
@@ -31,7 +32,7 @@ test('The test function receives a value from the generator', () => {
 
 test('Given a succeeding property function, the test function is only called once for each iteration', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
-    .extend(({ iterations }) => arbitraryGens({ minLength: iterations, minGens: 0 }))
+    .extend(({ iterations }) => arbitraryGens({ minLength: iterations }))
     .extend(() => arbitrarySucceedingPropertyFunction())
     .toArbitrary();
 
@@ -49,10 +50,11 @@ test('Given a succeeding property function, the test function is only called onc
 
 test('Given an exhausting generator, the property does not hold', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
-    .extend(({ iterations }) =>
-      arbitraryGens({ minLength: iterations })
-        .map((gs) => [...gs, GenStub.exhausted()])
-        .chain(arbitrarilyShuffleArray),
+    .extend(
+      ({ iterations }) =>
+        arbitraryGens({ minLength: iterations })
+          .map((gs) => [...gs, GenStub.exhausted()])
+          .chain(arbitrarilyShuffleArray) as fc.Arbitrary<Gens>,
     )
     .extend(() => arbitrarySucceedingPropertyFunction())
     .toArbitrary();

--- a/packages/pbt-properties-core/test/simpleProofs.test.ts
+++ b/packages/pbt-properties-core/test/simpleProofs.test.ts
@@ -9,7 +9,7 @@ import {
 
 test('Given a succeeding property function, the property holds', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
-    .extend(({ iterations }) => arbitraryGens({ minLength: iterations, minGens: 0 }))
+    .extend(({ iterations }) => arbitraryGens({ minLength: iterations }))
     .extend(() => arbitrarySucceedingPropertyFunction())
     .toArbitrary();
 
@@ -26,7 +26,7 @@ test('Given a succeeding property function, the property holds', () => {
 
 test('Given a false predicate, the property does not hold', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
-    .extend(({ iterations }) => arbitraryGens({ minLength: iterations, minGens: 0 }))
+    .extend(({ iterations }) => arbitraryGens({ minLength: iterations }))
     .toArbitrary();
 
   stableAssert(

--- a/packages/pbt-properties-core/test/validation.test.ts
+++ b/packages/pbt-properties-core/test/validation.test.ts
@@ -12,7 +12,7 @@ import { DEFAULT_MAX_ITERATIONS } from './helpers/constants';
 
 test('Given iterations = 0, the property returns a validation failure', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
-    .extend(({ iterations }) => arbitraryGens({ minLength: iterations, minGens: 0 }))
+    .extend(({ iterations }) => arbitraryGens({ minLength: iterations }))
     .extend(() => arbitraryPropertyFunction())
     .toArbitrary();
 
@@ -35,7 +35,7 @@ test('Given iterations = 0, the property returns a validation failure', () => {
 
 test('Given iterations < 0, the property returns a validation failure', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
-    .extend(({ iterations }) => arbitraryGens({ minLength: iterations, minGens: 0 }))
+    .extend(({ iterations }) => arbitraryGens({ minLength: iterations }))
     .extend(() => arbitraryPropertyFunction())
     .extend(() => fc.integer(-1))
     .toArbitrary();
@@ -59,7 +59,7 @@ test('Given iterations < 0, the property returns a validation failure', () => {
 
 test('Given iterations is a decimal, the property returns a validation failure', () => {
   const arb = arbitraryExtendableTuple(arbitraryPropertyConfig())
-    .extend(({ iterations }) => arbitraryGens({ minLength: iterations, minGens: 0 }))
+    .extend(({ iterations }) => arbitraryGens({ minLength: iterations }))
     .extend(() => arbitraryPropertyFunction())
     .extend(() => arbitraryDecimal(1, DEFAULT_MAX_ITERATIONS))
     .toArbitrary();


### PR DESCRIPTION
A property based on 0 generators is not valuable.

It also complicates tests later on. A property with 0 generators opens the opportunity for false-positive test cases, where we want to make an assertion _for all_ generators.