### PR TITLE
🌟 #90 `sample` throws on error now

### DIFF
--- a/packages/pbt/src/Core/Result.ts
+++ b/packages/pbt/src/Core/Result.ts
@@ -1,0 +1,47 @@
+type InnerResult<T, TError> = { type: 'success'; value: T } | { type: 'error'; error: TError };
+
+export class Result<T, TError> {
+  static ofValue<T, TError>(value: T): Result<T, TError> {
+    return new Result<T, TError>({ type: 'success', value });
+  }
+
+  static ofError<T, TError>(error: TError): Result<T, TError> {
+    return new Result<T, TError>({ type: 'error', error });
+  }
+
+  private constructor(private inner: InnerResult<T, TError>) {}
+
+  match<U>(successFn: (value: T) => U, errorFn: (error: TError) => U): U {
+    return this.inner.type === 'success' ? successFn(this.inner.value) : errorFn(this.inner.error);
+  }
+
+  map<U>(f: (value: T) => U): Result<U, TError> {
+    return this.match(
+      (value) => Result.ofValue<U, TError>(f(value)),
+      (error) => Result.ofError<U, TError>(error),
+    );
+  }
+
+  mapError<UError>(f: (error: TError) => UError): Result<T, UError> {
+    return this.match(
+      (value) => Result.ofValue<T, UError>(value),
+      (error) => Result.ofError<T, UError>(f(error)),
+    );
+  }
+
+  flatten(): T | TError {
+    return this.match<T | TError>(
+      (x) => x,
+      (x) => x,
+    );
+  }
+
+  asOk(makeThrowable: (error: TError) => Error): T {
+    return this.match<T>(
+      (value) => value,
+      (error) => {
+        throw makeThrowable(error);
+      },
+    );
+  }
+}

--- a/packages/pbt/src/Runners/index.ts
+++ b/packages/pbt/src/Runners/index.ts
@@ -1,1 +1,1 @@
-export * from './Sample';
+export { sample, sampleTrees, Sample, SampleConfig } from './Sample';

--- a/packages/pbt/test/Gen2/Gen.Array.test.ts
+++ b/packages/pbt/test/Gen2/Gen.Array.test.ts
@@ -1,7 +1,6 @@
 import fc from 'fast-check';
 import * as dev from './srcShim';
 import * as domainGen from './Helpers/domainGen';
-import { failwith } from './Helpers/failwith';
 
 const genArrayLength = () => domainGen.integer({ min: 0, max: 10 });
 
@@ -10,10 +9,9 @@ test('snapshot', () => {
     const seed = 0;
     const gen = dev.Gen.array(dev.Gen.integer().between(0, 10));
 
-    const sampleResult = dev.sampleTrees(gen, { seed, size: i * 10, iterations: 1 });
+    const sample = dev.sampleTrees(gen, { seed, size: i * 10, iterations: 1 });
 
-    if (sampleResult.kind !== 'success') return failwith('Expected success');
-    expect(dev.GenTree.format(sampleResult.values[0])).toMatchSnapshot(i.toString());
+    expect(dev.GenTree.format(sample.values[0])).toMatchSnapshot(i.toString());
   }
 });
 
@@ -136,13 +134,7 @@ describe('errors', () => {
       fc.property(domainGen.sampleConfig(), domainGen.gen(), domainGen.decimalWithAtLeastOneDp(), (config, gen, x) => {
         const genArray = dev.Gen.array(gen).ofMinLength(x);
 
-        const sampleResult = dev.sample(genArray, config);
-
-        const expectedSampleResult: dev.SampleResult<number> = {
-          kind: 'error',
-          message: expect.stringMatching('Minimum must be an integer'),
-        };
-        expect(sampleResult).toEqual(expectedSampleResult);
+        expect(() => dev.sample(genArray, config)).toThrowError('Minimum must be an integer');
       }),
     );
   });
@@ -152,13 +144,7 @@ describe('errors', () => {
       fc.property(domainGen.sampleConfig(), domainGen.gen(), domainGen.decimalWithAtLeastOneDp(), (config, gen, x) => {
         const genArray = dev.Gen.array(gen).ofMaxLength(x);
 
-        const sampleResult = dev.sample(genArray, config);
-
-        const expectedSampleResult: dev.SampleResult<number> = {
-          kind: 'error',
-          message: expect.stringMatching('Maximum must be an integer'),
-        };
-        expect(sampleResult).toEqual(expectedSampleResult);
+        expect(() => dev.sample(genArray, config)).toThrow('Maximum must be an integer');
       }),
     );
   });
@@ -168,13 +154,7 @@ describe('errors', () => {
       fc.property(domainGen.sampleConfig(), domainGen.gen(), domainGen.integer({ max: -1 }), (config, gen, x) => {
         const genArray = dev.Gen.array(gen).ofMinLength(x);
 
-        const sampleResult = dev.sample(genArray, config);
-
-        const expectedSampleResult: dev.SampleResult<number> = {
-          kind: 'error',
-          message: expect.stringMatching('Minimum must be at least 0'),
-        };
-        expect(sampleResult).toEqual(expectedSampleResult);
+        expect(() => dev.sample(genArray, config)).toThrow('Minimum must be at least 0');
       }),
     );
   });
@@ -184,13 +164,7 @@ describe('errors', () => {
       fc.property(domainGen.sampleConfig(), domainGen.gen(), domainGen.integer({ max: -1 }), (config, gen, x) => {
         const genArray = dev.Gen.array(gen).ofMaxLength(x);
 
-        const sampleResult = dev.sample(genArray, config);
-
-        const expectedSampleResult: dev.SampleResult<number> = {
-          kind: 'error',
-          message: expect.stringMatching('Maximum must be at least 0'),
-        };
-        expect(sampleResult).toEqual(expectedSampleResult);
+        expect(() => dev.sample(genArray, config)).toThrow('Maximum must be at least 0');
       }),
     );
   });

--- a/packages/pbt/test/Gen2/Gen.Map.test.ts
+++ b/packages/pbt/test/Gen2/Gen.Map.test.ts
@@ -1,20 +1,17 @@
 import fc from 'fast-check';
 import * as dev from './srcShim';
 import * as domainGen from './Helpers/domainGen';
-import { failwith } from './Helpers/failwith';
 
 test('sample(gen.map(f)).values = sample(gen).values.map(f)', () => {
   fc.assert(
     fc.property(domainGen.sampleConfig(), domainGen.gen(), fc.func(fc.anything()), (config, gen, f) => {
       const genMapped = gen.map((x) => f(x));
 
-      const mappedSampleResult = dev.sampleTrees(genMapped, config);
-      const unmappedSampleResult = dev.sampleTrees(gen, config);
-      if (mappedSampleResult.kind === 'error' || unmappedSampleResult.kind === 'error')
-        return failwith('Expected success');
+      const mappedSample = dev.sampleTrees(genMapped, config);
+      const unmappedSample = dev.sampleTrees(gen, config);
 
-      const actualTrees = mappedSampleResult.values.map(dev.GenTree.traverseGreedy);
-      const expectedTrees = unmappedSampleResult.values
+      const actualTrees = mappedSample.values.map(dev.GenTree.traverseGreedy);
+      const expectedTrees = unmappedSample.values
         .map((tree) => dev.GenTree.map(tree, f))
         .map(dev.GenTree.traverseGreedy);
       expect(actualTrees).toEqual(expectedTrees);

--- a/packages/pbt/test/Gen2/Helpers/domainGen.ts
+++ b/packages/pbt/test/Gen2/Helpers/domainGen.ts
@@ -11,13 +11,6 @@ export const size = (): fc.Arbitrary<devCore.Size> => fc.integer(0, 100);
 export const sampleConfig = (): fc.Arbitrary<SampleConfig> =>
   fc.tuple(seed(), size(), integer(1, 100)).map(([seed, size, iterations]) => ({ seed, size, iterations }));
 
-export const sampleFunc = <T>(): fc.Arbitrary<(gen: dev.Gen<T>) => dev.SampleResult<T>> =>
-  fc.tuple(seed(), size(), integer(1, 100)).map(([seed, size, iterations]) => {
-    const f = (gen: dev.Gen<T>) => dev.sample(gen, { seed, size, iterations });
-    f.toString = () => `sample(gen, { seed: ${seed.valueOf()}, size: ${size}, iterations: ${iterations}})`;
-    return f;
-  });
-
 export const scaleMode = (): fc.Arbitrary<devGenRange.ScaleMode> => {
   const scaleModeExhaustive: { [P in devGenRange.ScaleMode]: P } = {
     constant: 'constant',

--- a/packages/pbt/test/Gen2/Helpers/failwith.ts
+++ b/packages/pbt/test/Gen2/Helpers/failwith.ts
@@ -1,3 +1,0 @@
-export const failwith = (str: string): void => {
-  throw new Error(str);
-};


### PR DESCRIPTION
Contributes to #90

Unfortunately this is a better API, without a native result type =/