### PR TITLE
💎 #134 Fixes of jest integration

### DIFF
--- a/packages/pbt-jest/package.json
+++ b/packages/pbt-jest/package.json
@@ -13,16 +13,14 @@
   "files": [
     "lib/"
   ],
-  "dependencies": {
-    "jest": "^26.4.1",
-    "pbt": "0.0.0"
-  },
   "devDependencies": {
     "@types/jest": "^26.0.10",
+    "jest": "^26.4.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "pbt": "^0.0.0"
   },
   "scripts": {
     "build": "tsc --project tsconfig.esm.json && tsc --project tsconfig.cjs.json",
@@ -33,5 +31,9 @@
     "test": "jest --coverage --no-cache",
     "test:watch": "jest --watchAll --no-cache",
     "sandbox": "ts-node --project scripts/tsconfig.json scripts/sandbox"
+  },
+  "peerDependencies": {
+    "jest": "^26.4.1",
+    "pbt": "^0.0.0"
   }
 }

--- a/packages/pbt-jest/src/index.ts
+++ b/packages/pbt-jest/src/index.ts
@@ -44,3 +44,7 @@ export const bind = (itLike: typeof it) => (...args: NullaryPropertyArgs | Varia
 };
 
 it.property = bind(it);
+it.skip.property = bind(it.skip);
+it.only.property = bind(it.only);
+it.todo.property = bind(it.todo);
+it.concurrent.property = bind(it.concurrent);

--- a/packages/pbt-jest/test/Integration.test.ts
+++ b/packages/pbt-jest/test/Integration.test.ts
@@ -17,3 +17,10 @@ test
     expect(x).toEqual(717354021); // Saaaaaaahhhh rand0m
   })
   .config({ seed: 1, size: 50, iterations: 1 });
+
+test('it augments the other test fns', () => {
+  expect(typeof test.skip.property).toEqual('function');
+  expect(typeof test.only.property).toEqual('function');
+  expect(typeof test.todo.property).toEqual('function');
+  expect(typeof test.concurrent.property).toEqual('function');
+});

--- a/packages/pbt/e2e/ShrinkingChallenges.test.ts
+++ b/packages/pbt/e2e/ShrinkingChallenges.test.ts
@@ -1,42 +1,38 @@
-import fc from 'fast-check';
 import { max } from 'ix/iterable';
-import { assert, property } from 'pbt-vnext';
 import * as dev from '../src';
 import * as domainGen from './domainGen';
 
-test('Fallacy: the array is in reverse order', () => {
-  // Based on: https://github.com/jlink/shrinking-challenge/blob/main/challenges/reverse.md
-  assert(
-    property(domainGen.seed(), domainGen.size(), (seed, size) => {
-      const g = dev.Gen.integer().array();
-      const m = dev.minimal(
-        g,
-        (xs) => {
-          const xs0 = [...xs].sort((a, b) => b - a);
-          return xs.every((x, i) => x === xs0[i]);
-        },
-        { seed, size },
-      );
+// Based on: https://github.com/jlink/shrinking-challenge/blob/main/challenges/reverse.md
+test.property('Fallacy: the array is in reverse order', domainGen.seed(), domainGen.size(), (seed, size) => {
+  const g = dev.Gen.integer().array();
 
-      expect([
-        [0, 1],
-        [-1, 0],
-      ]).toContainEqual(m);
-    }),
+  const m = dev.minimal(
+    g,
+    (xs) => {
+      const xs0 = [...xs].sort((a, b) => b - a);
+      return xs.every((x, i) => x === xs0[i]);
+    },
+    { seed, size },
   );
+
+  expect([
+    [0, 1],
+    [-1, 0],
+  ]).toContainEqual(m);
 });
 
-test('Fallacy: the array does not contain a value >= 900', () => {
-  // Based on: https://github.com/jlink/shrinking-challenge/blob/main/challenges/lengthlist.md
-  assert(
-    property(domainGen.seed(), domainGen.size(), (seed, size) => {
-      const g = dev.Gen.integer()
-        .between(1, 100)
-        .flatMap((length) => dev.Gen.integer().between(0, 1000).array().ofLength(length));
+// Based on: https://github.com/jlink/shrinking-challenge/blob/main/challenges/lengthlist.md
+test.property(
+  'Fallacy: the array does not contain a value >= 900',
+  domainGen.seed(),
+  domainGen.size(),
+  (seed, size) => {
+    const g = dev.Gen.integer()
+      .between(1, 100)
+      .flatMap((length) => dev.Gen.integer().between(0, 1000).array().ofLength(length));
 
-      const m = dev.minimal(g, (xs) => max(xs) < 900, { seed, size });
+    const m = dev.minimal(g, (xs) => max(xs) < 900, { seed, size });
 
-      expect(m).toEqual([900]);
-    }),
-  );
-});
+    expect(m).toEqual([900]);
+  },
+);

--- a/packages/pbt/jest.setup.js
+++ b/packages/pbt/jest.setup.js
@@ -1,3 +1,4 @@
+require('pbt-jest-vnext');
 const fc = require('fast-check');
 const pbt = require('pbt-vnext');
 

--- a/packages/pbt/package.json
+++ b/packages/pbt/package.json
@@ -21,6 +21,7 @@
     "cross-env": "^7.0.2",
     "fast-check": "^2.2.0",
     "jest": "^26.4.1",
+    "pbt-jest-vnext": "npm:pbt-jest@0.0.1-alpha.166",
     "pbt-vnext": "npm:pbt@0.0.1-alpha.163",
     "rimraf": "^3.0.2",
     "simple-statistics": "^7.3.0",
@@ -36,7 +37,7 @@
     "build:clean": "rimraf lib",
     "test": "cross-env fastCheckRuns=25 jest --coverage --no-cache",
     "test:fast": "cross-env fastCheckRuns=5 jest --coverage --no-cache",
-    "test:deep": "cross-env fastCheckRuns=100 jest --coverage --no-cache",
+    "test:deep": "cross-env fastCheckRuns=50 jest --coverage --no-cache",
     "test:watch": "cross-env fastCheckRuns=5 jest --watchAll --no-cache",
     "sandbox": "ts-node --project scripts/tsconfig.json scripts/sandbox"
   }

--- a/packages/pbt/tsconfig.test.json
+++ b/packages/pbt/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.esm.json",
   "compilerOptions": {
-    "types": ["node", "jest"],
+    "types": ["node", "jest", "pbt-jest-vnext"],
     "esModuleInterop": true,
     "noEmit": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5538,10 +5538,25 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+"pbt-jest-vnext@npm:pbt-jest@0.0.1-alpha.166":
+  version "0.0.1-alpha.166"
+  resolved "https://registry.yarnpkg.com/pbt-jest/-/pbt-jest-0.0.1-alpha.166.tgz#a2531542acc4e06468b6d3934d871a023223a088"
+  integrity sha512-z3EHsprMJA45EDOMFca+RZtcQEZnpJbSFrm/RLPhW19IUyBj1aFx2PRy8XdPsfH8Hi22zxQKRL1pFffdVQkdSA==
+  dependencies:
+    jest "^26.4.1"
+    pbt "^0.0.1-alpha.166+4e82543"
+
 "pbt-vnext@npm:pbt@0.0.1-alpha.163":
   version "0.0.1-alpha.163"
   resolved "https://registry.yarnpkg.com/pbt/-/pbt-0.0.1-alpha.163.tgz#10a098d8d7862148759284de38a6362997800816"
   integrity sha512-R+WZLuoUEkFsTdHZaW5qO3MTn8KOVJoz95fb0VsvCIr8SYIwij9BaIXGhTiXykQuE58uWnBB4uhuY1x/SWNLjQ==
+  dependencies:
+    ix "^4.0.0"
+
+pbt@^0.0.1-alpha.166+4e82543:
+  version "0.0.1-alpha.167"
+  resolved "https://registry.yarnpkg.com/pbt/-/pbt-0.0.1-alpha.167.tgz#3a4264dd76fcf4226b78f2a66fc3d08207c478b7"
+  integrity sha512-YwRskYBtFFAcj2pzq+Ua4t4q5kHK62Ir5BOgdzajrIqHX7N/nDbyBe4bEG/ye9NV/XAoUZ7XLpNGDy/zejJ7pw==
   dependencies:
     ix "^4.0.0"
 
@@ -7227,9 +7242,9 @@ write-pkg@^3.1.0:
     write-json-file "^2.2.0"
 
 ws@^7.2.3:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
-  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.0.tgz#a5dd76a24197940d4a8bb9e0e152bb4503764da7"
+  integrity sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -7262,9 +7277,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@20.x, yargs-parser@^20.2.3:
-  version "20.2.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.3.tgz#92419ba867b858c868acf8bae9bf74af0dd0ce26"
-  integrity sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-parser@^15.0.1:
   version "15.0.1"


### PR DESCRIPTION
Contributes to: #134 

- pbt is a peer dependency, so it should use the same global conf
- also augment test.skip, test.only, and others