### PR TITLE
🔧 Increase timeouts

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     env:
       NODE_OPTIONS: --max_old_space_size=8192
 

--- a/.github/workflows/test-master.yml
+++ b/.github/workflows/test-master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       NODE_OPTIONS: --max_old_space_size=8192
 


### PR DESCRIPTION
...so we don't get locked out if we accidentally run the tests too much.