### PR TITLE
🔧 On master, build before deep test

### DIFF
--- a/.github/workflows/build-and-publish-master.yml
+++ b/.github/workflows/build-and-publish-master.yml
@@ -22,9 +22,6 @@ jobs:
     - name: Build
       run: yarn build
 
-    - name: Prettier
-      run: yarn prettier:check
-
     - name: Configure NPM
       run: echo '//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}' >> .npmrc
 

--- a/.github/workflows/test-master.yml
+++ b/.github/workflows/test-master.yml
@@ -19,6 +19,9 @@ jobs:
     - name: Restore packages
       run: yarn
 
+    - name: Build
+      run: yarn build
+
     - name: Test
       run: yarn test:deep
 


### PR DESCRIPTION
This isn't required right now, but might get us later on if we have some linked packages.