### PR TITLE
💎 #144 Better sized properties

### DIFF
--- a/packages/pbt/src/Core/RandomStream.ts
+++ b/packages/pbt/src/Core/RandomStream.ts
@@ -1,3 +1,0 @@
-export type RandomStream<T, TConfig = never> = {
-  run(seed: number, size: number, config?: TConfig): Iterable<T>;
-};

--- a/packages/pbt/src/Core/index.ts
+++ b/packages/pbt/src/Core/index.ts
@@ -1,5 +1,4 @@
 export * from './Size';
-export * from './RandomStream';
 export * from './Result';
 export * from './iterableOperators';
 export * from './Rng';

--- a/packages/pbt/src/Gen/Abstractions.ts
+++ b/packages/pbt/src/Gen/Abstractions.ts
@@ -1,13 +1,13 @@
-import { RandomStream, Rng } from '../Core';
+import { Rng, Size } from '../Core';
 import { GenFunction } from './GenFunction';
 import { GenIteration } from './GenIteration';
 import { ScaleMode } from './Range';
 
-export type GenConfig = Partial<{
-  makeRng: (seed: number) => Rng;
-}>;
+export type GenConfig = {
+  makeRng?: (seed: number) => Rng;
+};
 
-export interface Gen<T> extends RandomStream<GenIteration<T>, GenConfig> {
+export interface Gen<T> {
   /**
    * @description The underlying function that is built up by all operations on a Gen.
    * @private
@@ -19,6 +19,7 @@ export interface Gen<T> extends RandomStream<GenIteration<T>, GenConfig> {
   filter(predicate: (x: T) => boolean): Gen<T>;
   noShrink(): Gen<T>;
   noComplexity(): Gen<T>;
+  run(seed: number, size: Size, config?: GenConfig): Iterable<GenIteration<T>>;
 }
 
 export type ArrayGen<T> = Gen<T[]> & {

--- a/packages/pbt/src/Gen/Gen.ts
+++ b/packages/pbt/src/Gen/Gen.ts
@@ -21,7 +21,7 @@ export namespace Gen {
   export function create<T>(
     f: GenInstanceStatefulFunction<T>,
     shrink: Shrinker<T>,
-    calculateComplexity: CalculateComplexity<T>,
+    calculateComplexity: CalculateComplexity<T> = () => 0,
   ): Gen<T> {
     return new BaseGen(GenFunction.create(f, shrink, calculateComplexity), genFactory);
   }

--- a/packages/pbt/src/Property/Abstractions.ts
+++ b/packages/pbt/src/Property/Abstractions.ts
@@ -1,4 +1,4 @@
-import { RandomStream } from '../Core';
+import { Size } from '../Core';
 import { Complexity } from '../GenTree';
 import { GenIteration } from '../Gen';
 
@@ -84,7 +84,10 @@ export namespace PropertyFunction {
 }
 
 export type PropertyConfig = {
-  path: string;
+  path?: string;
+  size?: Size;
 };
 
-export type Property<Ts extends any[]> = RandomStream<PropertyIteration<Ts>, Partial<PropertyConfig>>;
+export type Property<Ts extends any[]> = {
+  run(seed: number, iterations: number, config?: PropertyConfig): Iterable<PropertyIteration<Ts>>;
+};

--- a/packages/pbt/src/Property/calculatePropertySizes.ts
+++ b/packages/pbt/src/Property/calculatePropertySizes.ts
@@ -1,0 +1,29 @@
+import { pipe, repeatValue } from 'ix/iterable';
+import { flatMap, take } from 'ix/iterable/operators';
+import { Size } from '../Core';
+
+const arrayRange = (n: number): number[] => [...Array(n).keys()];
+
+export const calculatePropertySizes = (iterations: number, requestedSize?: Size): Iterable<Size> => {
+  if (iterations < 0 || !Number.isInteger(iterations)) throw new Error('Fatal: Iterations must be positive integer');
+
+  if (requestedSize !== undefined) {
+    if (requestedSize < 0 || requestedSize > 99 || !Number.isInteger(requestedSize))
+      throw new Error('Fatal: Size must integer in [0 .. 99]');
+
+    return pipe(repeatValue(requestedSize), take(iterations));
+  }
+
+  if (iterations === 0) return [];
+  if (iterations === 1) return [0];
+  if (iterations <= 99) {
+    const sizeIncrement = Math.floor(100 / (iterations - 1));
+    return [0, ...arrayRange(iterations - 2).map((n) => sizeIncrement * (n + 1)), 99];
+  }
+
+  return pipe(
+    repeatValue(null),
+    flatMap(() => arrayRange(100)),
+    take(iterations),
+  );
+};

--- a/packages/pbt/src/Runners/DefaultConfig.ts
+++ b/packages/pbt/src/Runners/DefaultConfig.ts
@@ -2,7 +2,6 @@ import { Size } from '../Core';
 
 export type DefaultConfig = {
   seed: number;
-  size: Size;
   iterations: number;
 };
 
@@ -15,11 +14,10 @@ export function defaultConfig(config: Partial<DefaultConfig>): void {
 /**
  * @private
  */
-export function getDefaultConfig(runnerSpecificDefaultConfig: Pick<DefaultConfig, 'size'>): Readonly<DefaultConfig> {
+export function getDefaultConfig(): Readonly<DefaultConfig> {
   return {
     iterations: 100,
     seed: Date.now(),
-    ...runnerSpecificDefaultConfig,
     ...setDefaultConfig,
   };
 }

--- a/packages/pbt/src/Runners/Minimal.ts
+++ b/packages/pbt/src/Runners/Minimal.ts
@@ -6,7 +6,7 @@ import { getDefaultConfig } from './DefaultConfig';
 
 export type MinimalConfig = {
   seed: number;
-  size: Size;
+  size: Size | undefined;
   iterations: number;
 };
 
@@ -21,10 +21,11 @@ export function minimal<T>(g: Gen<T>, config: Partial<MinimalConfig>): T;
 export function minimal<T>(g: Gen<T>, predicate: (x: T) => boolean): T;
 export function minimal<T>(g: Gen<T>, predicate: (x: T) => boolean, config: Partial<MinimalConfig>): T;
 export function minimal<T>(...args: MinimalArgs<T>): T {
-  const [g, predicateOrUndefined, configOrUndefined] = resolveArgs(args);
+  const [g, predicateOrUndefined, configOrUndefined] = normalizeArgs(args);
   const predicate = predicateOrUndefined || (() => true);
   const config: MinimalConfig = {
-    ...getDefaultConfig({ size: 0 }),
+    size: undefined,
+    ...getDefaultConfig(),
     ...(configOrUndefined || {}),
   };
 
@@ -38,7 +39,7 @@ export function minimal<T>(...args: MinimalArgs<T>): T {
   return c.counterexample.value[0];
 }
 
-const resolveArgs = <T>(
+const normalizeArgs = <T>(
   args: MinimalArgs<T>,
 ): [Gen<T>, ((x: T) => boolean) | undefined, Partial<MinimalConfig> | undefined] => {
   switch (args.length) {

--- a/packages/pbt/src/Runners/Sample.ts
+++ b/packages/pbt/src/Runners/Sample.ts
@@ -52,7 +52,8 @@ type SampleAccumulator<T> = {
 
 export const sampleTreesInternal = <T>(gen: Gen<T>, config: Partial<SampleConfig> = {}): SampleResult<GenTree<T>> => {
   const { seed, size, iterations: iterationCount }: SampleConfig = {
-    ...getDefaultConfig({ size: 30 }),
+    size: 0,
+    ...getDefaultConfig(),
     ...config,
   };
 

--- a/packages/pbt/src/index.ts
+++ b/packages/pbt/src/index.ts
@@ -1,4 +1,4 @@
-export { RandomStream, Rng, Size } from './Core';
+export { Rng, Size } from './Core';
 export { GenTree, GenTreeNode, Complexity, CalculateComplexity } from './GenTree';
 export { Gen, Shrink, Shrinker, GenIteration } from './Gen';
 export { property, Property, PropertyIteration, PropertyFunction, ShrinkIteration, Counterexample } from './Property';

--- a/packages/pbt/test/Core/Helpers/domainGen.ts
+++ b/packages/pbt/test/Core/Helpers/domainGen.ts
@@ -1,22 +1,5 @@
 import * as stable from 'pbt';
 
-export type AnyArray = any[];
-export type AnyNonEmptyArray = [any, ...AnyArray];
-export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
-
-export const choose = <Ts extends AnyArray | AnyNonEmptyArray>(
-  ...gens: Ts extends AnyNonEmptyArray ? { [P in keyof Ts]: stable.Gen<Ts[P]> } : stable.Gen<ArrayElement<Ts>>[]
-): stable.Gen<ArrayElement<Ts>> => {
-  const numberOfGens = gens.length;
-  if (numberOfGens === 0) {
-    throw new Error('Expected at least one gen');
-  }
-
-  return stable.Gen.integer()
-    .between(0, numberOfGens)
-    .flatMap((i) => gens[i]);
-};
-
 export const element = <T>(...elements: T[]): stable.Gen<T> => {
   const numberOfElements = elements.length;
   if (numberOfElements === 0) {

--- a/packages/pbt/test/Helpers/domainGen.ts
+++ b/packages/pbt/test/Helpers/domainGen.ts
@@ -45,7 +45,7 @@ export const func = <T, TArgs extends any[] = unknown[]>(
 
 export const seed = (): fc.Arbitrary<number> => fc.nat().noShrink();
 
-export const size = (): fc.Arbitrary<devCore.Size> => fc.integer(0, 100);
+export const size = (): fc.Arbitrary<devCore.Size> => fc.integer(0, 99);
 
 export const sampleConfig = (): fc.Arbitrary<dev.SampleConfig> =>
   fc.tuple(seed(), size(), integer(1, 100)).map(([seed, size, iterations]) => ({ seed, size, iterations }));

--- a/packages/pbt/test/Helpers/domainGenV2.ts
+++ b/packages/pbt/test/Helpers/domainGenV2.ts
@@ -1,7 +1,31 @@
 import { Gen } from 'pbt';
 
-export const anything = (): Gen<unknown> => Gen.constant({});
+export type AnyArray = any[];
+export type AnyNonEmptyArray = [any, ...AnyArray];
+export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
-export const seed = (): Gen<number> => Gen.integer().growBy('constant').noShrink();
+export namespace DomainGenV2 {
+  export const anything = (): Gen<unknown> => Gen.constant({});
 
-export const size = (): Gen<number> => Gen.integer().between(0, 99);
+  export const seed = (): Gen<number> => Gen.integer().growBy('constant').noShrink();
+
+  export const size = (): Gen<number> => Gen.integer().between(0, 99);
+
+  export type AnyArray = any[];
+  export type AnyNonEmptyArray = [any, ...AnyArray];
+  export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
+
+  export const choose = <Ts extends AnyArray | AnyNonEmptyArray>(
+    ...gens: Ts extends AnyNonEmptyArray ? { [P in keyof Ts]: Gen<Ts[P]> } : Gen<ArrayElement<Ts>>[]
+  ): Gen<ArrayElement<Ts>> => {
+    const numberOfGens = gens.length;
+    if (numberOfGens === 0) {
+      throw new Error('Expected at least one gen');
+    }
+
+    return Gen.integer()
+      .between(0, numberOfGens - 1)
+      .growBy('constant')
+      .flatMap((i) => gens[i]);
+  };
+}

--- a/packages/pbt/test/Helpers/domainGenV2.ts
+++ b/packages/pbt/test/Helpers/domainGenV2.ts
@@ -1,9 +1,5 @@
 import { Gen } from 'pbt';
 
-export type AnyArray = any[];
-export type AnyNonEmptyArray = [any, ...AnyArray];
-export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
-
 export namespace DomainGenV2 {
   export const anything = (): Gen<unknown> => Gen.constant({});
 
@@ -11,13 +7,7 @@ export namespace DomainGenV2 {
 
   export const size = (): Gen<number> => Gen.integer().between(0, 99);
 
-  export type AnyArray = any[];
-  export type AnyNonEmptyArray = [any, ...AnyArray];
-  export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
-
-  export const choose = <Ts extends AnyArray | AnyNonEmptyArray>(
-    ...gens: Ts extends AnyNonEmptyArray ? { [P in keyof Ts]: Gen<Ts[P]> } : Gen<ArrayElement<Ts>>[]
-  ): Gen<ArrayElement<Ts>> => {
+  export const choose = <T>(...gens: Gen<T>[]): Gen<T> => {
     const numberOfGens = gens.length;
     if (numberOfGens === 0) {
       throw new Error('Expected at least one gen');

--- a/packages/pbt/test/Property/Property.Sizing.test.ts
+++ b/packages/pbt/test/Property/Property.Sizing.test.ts
@@ -1,0 +1,113 @@
+import { count, first, last, pipe, repeatValue } from 'ix/iterable';
+import { flatMap, take } from 'ix/iterable/operators';
+import { Gen } from 'pbt';
+import * as dev from '../../src';
+import { DomainGenV2 } from '../Helpers/domainGenV2';
+
+const arrayRange = (n: number): number[] => [...Array(n).keys()];
+
+const calculatePropertySizes = (iterations: number, requestedSize?: dev.Size): Iterable<dev.Size> => {
+  if (iterations < 0 || !Number.isInteger(iterations)) throw new Error('Fatal: Iterations must be positive integer');
+
+  if (requestedSize !== undefined) {
+    if (requestedSize < 0 || requestedSize > 99 || !Number.isInteger(requestedSize))
+      throw new Error('Fatal: Size must integer in [0 .. 99]');
+
+    return pipe(repeatValue(requestedSize), take(iterations));
+  }
+
+  if (iterations === 0) return [];
+  if (iterations === 1) return [0];
+  if (iterations <= 99) {
+    const sizeIncrement = Math.round(100 / (iterations - 1));
+    return [0, ...arrayRange(iterations - 2).map((n) => sizeIncrement * (n + 1)), 99];
+  }
+
+  return pipe(
+    repeatValue(null),
+    flatMap(() => arrayRange(100)),
+    take(iterations),
+  );
+};
+
+describe('unit tests', () => {
+  test.each([
+    [0, []],
+    [1, [0]],
+    [2, [0, 99]],
+    [3, [0, 50, 99]],
+    [4, [0, 33, 66, 99]],
+  ])('iterations = %i, sizes = %p', (iterations, expectedSizes) => {
+    const sizes = calculatePropertySizes(iterations);
+
+    expect(sizes).toEqual(expectedSizes);
+  });
+
+  test.property(
+    'iterations < 0 || iterations ∉ ℤ, *throws*',
+    DomainGenV2.choose(
+      Gen.integer().lessThanEqual(-1),
+      Gen.integer().map((x) => x + 0.1), // Hacky way to consistently produce a decimal
+    ),
+    (iterations) => {
+      expect(() => calculatePropertySizes(iterations)).toThrow('Fatal: Iterations must be positive integer');
+    },
+  );
+
+  test.property('first(sizes) = 0', Gen.integer().between(1, 1000), (iterations) => {
+    const sizes = calculatePropertySizes(iterations);
+
+    expect(first(sizes)).toEqual(0);
+  });
+
+  test.property('if iterations ∈ [2, 99], last(sizes) = 99', Gen.integer().between(2, 99), (iterations) => {
+    const sizes = calculatePropertySizes(iterations);
+
+    expect(last(sizes)).toEqual(99);
+  });
+
+  test.property('if iterations < 99, count(sizes) = iterations', Gen.integer().between(0, 99), (iterations) => {
+    const sizes = calculatePropertySizes(iterations);
+
+    expect(count(sizes)).toEqual(iterations);
+  });
+
+  test.property('if iterations >= 100, count(sizes) = 100', Gen.integer().between(100, 1000), (iterations) => {
+    const sizes = calculatePropertySizes(iterations);
+
+    expect(count(sizes)).toEqual(iterations);
+  });
+
+  test.property('sizes ∈ [0 .. 99]', () => {});
+
+  describe('requestedSize', () => {
+    test.property(
+      'requestedSize < 0 || requestedSize > 99 || requestedSize ∉ ℤ, *throws*',
+      Gen.integer().greaterThanEqual(0),
+      DomainGenV2.choose(
+        Gen.integer().lessThanEqual(-1),
+        Gen.integer().greaterThanEqual(100),
+        Gen.integer().map((x) => x + 0.1), // Hacky way to consistently produce a decimal
+      ),
+      (iterations, requestedSize) => {
+        expect(() => calculatePropertySizes(iterations, requestedSize)).toThrow(
+          'Fatal: Size must integer in [0 .. 99]',
+        );
+      },
+    );
+
+    test.property(
+      'requestedSize is repeated for iterations',
+      Gen.integer().between(0, 1000),
+      DomainGenV2.size(),
+      (iterations, requestedSize) => {
+        const sizes = Array.from(calculatePropertySizes(iterations, requestedSize));
+
+        expect(sizes).toHaveLength(iterations);
+        for (const size of sizes) {
+          expect(size).toEqual(requestedSize);
+        }
+      },
+    );
+  });
+});

--- a/packages/pbt/test/Runners/DefaultConfig.test.ts
+++ b/packages/pbt/test/Runners/DefaultConfig.test.ts
@@ -1,7 +1,7 @@
 import { assert, property, Gen } from 'pbt';
 import * as dev from '../../src';
 import { PropertyConfig } from '../../src/Property/Abstractions';
-import * as domainGen from '../Helpers/domainGenV2';
+import { DomainGenV2 } from '../Helpers/domainGenV2';
 import * as spies from '../Helpers/spies';
 
 describe('sample', () => {
@@ -9,7 +9,7 @@ describe('sample', () => {
 
   it('respects default iterations', () => {
     assert(
-      property(Gen.integer().between(1, 100), domainGen.anything(), (iterations, value) => {
+      property(Gen.integer().between(1, 100), DomainGenV2.anything(), (iterations, value) => {
         const g = dev.Gen.constant(value);
 
         dev.defaultConfig({ iterations });
@@ -23,7 +23,7 @@ describe('sample', () => {
 
   it('respects default seed', () => {
     assert(
-      property(domainGen.seed(), domainGen.anything(), (seed, value) => {
+      property(DomainGenV2.seed(), DomainGenV2.anything(), (seed, value) => {
         const g = dev.Gen.constant(value);
 
         dev.defaultConfig({ seed });
@@ -37,7 +37,7 @@ describe('sample', () => {
 
   it('respects default size', () => {
     assert(
-      property(domainGen.size(), domainGen.anything(), (size, value) => {
+      property(DomainGenV2.size(), DomainGenV2.anything(), (size, value) => {
         const g = dev.Gen.constant(value);
 
         dev.defaultConfig({ size });
@@ -79,7 +79,7 @@ describe('check', () => {
 
   it('respects default seed', () => {
     assert(
-      property(domainGen.seed(), (seed) => {
+      property(DomainGenV2.seed(), (seed) => {
         const run = spies.spyOn<RunFn>(() => []);
         const p = new MockProperty(run);
 
@@ -95,7 +95,7 @@ describe('check', () => {
 
   it('respects default size', () => {
     assert(
-      property(domainGen.size(), (size) => {
+      property(DomainGenV2.size(), (size) => {
         const run = spies.spyOn<RunFn>(() => []);
         const p = new MockProperty(run);
 

--- a/packages/pbt/test/Runners/DefaultConfig.test.ts
+++ b/packages/pbt/test/Runners/DefaultConfig.test.ts
@@ -1,6 +1,5 @@
 import { assert, property, Gen } from 'pbt';
 import * as dev from '../../src';
-import { PropertyConfig } from '../../src/Property/Abstractions';
 import { DomainGenV2 } from '../Helpers/domainGenV2';
 import * as spies from '../Helpers/spies';
 
@@ -34,20 +33,6 @@ describe('sample', () => {
       }),
     );
   });
-
-  it('respects default size', () => {
-    assert(
-      property(DomainGenV2.size(), DomainGenV2.anything(), (size, value) => {
-        const g = dev.Gen.constant(value);
-
-        dev.defaultConfig({ size });
-
-        const s = dev.sample(g);
-
-        expect(s.size).toEqual(size);
-      }),
-    );
-  });
 });
 
 describe('check', () => {
@@ -58,8 +43,8 @@ describe('check', () => {
   class MockProperty implements dev.Property<any[]> {
     constructor(private runFn: RunFn) {}
 
-    run(seed: number, size: number, config?: Partial<PropertyConfig>): Iterable<dev.PropertyIteration<any[]>> {
-      return this.runFn(seed, size, config);
+    run(seed: number, iterations: number): Iterable<dev.PropertyIteration<any[]>> {
+      return this.runFn(seed, iterations);
     }
   }
 
@@ -89,22 +74,6 @@ describe('check', () => {
 
         const spiedSeed = spies.calls(run)[0][0];
         expect(spiedSeed).toEqual(seed);
-      }),
-    );
-  });
-
-  it('respects default size', () => {
-    assert(
-      property(DomainGenV2.size(), (size) => {
-        const run = spies.spyOn<RunFn>(() => []);
-        const p = new MockProperty(run);
-
-        dev.defaultConfig({ size });
-
-        dev.check(p);
-
-        const spiedSize = spies.calls(run)[0][1];
-        expect(spiedSize).toEqual(size);
       }),
     );
   });


### PR DESCRIPTION
Completes: #144

Properties always get the max size (99) when iterations > 1. Improves coverage in consumers in dev mode (running frequently with less iterations).